### PR TITLE
Changed to the app name configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,3 +102,4 @@ loader.toCombinedObject().then((configVars) => {
   // Do what you want with your configuratin
 })
 ```
+

--- a/src/loader/index.js
+++ b/src/loader/index.js
@@ -14,6 +14,12 @@ class Loader {
   };
 
   appNameRegex = () => {
+    const name = this.appName();
+    if (!name) {
+      console.log("ENV var `NAME` is missing. Please make sure you define it")
+
+      return null
+    }
     return new RegExp(`^${this.appName().toUpperCase()}__`, 'g');
   }
 
@@ -43,13 +49,14 @@ class Loader {
 
         getVars(version, secretsTable, this.parseBooleans).then((secrets) => {
           console.log(`Completed loading from table ${secretsTable}`) // eslint-disable-line
-          const combined = _.merge(envObject, secrets);
+          // add the name to the config without the need to namespace it under the app name env var
+          const combined = _.merge(envObject, secrets, { name: this.appName() });
           resolve(combined);
         }).catch((error) => {
           reject(`Error has occured fetching secrets: ${error}`);
         });
       } else {
-        resolve(envObject);
+        resolve(_.merge(envObject, { name: this.appName() }));
       }
     });
   }

--- a/src/loader/index.js
+++ b/src/loader/index.js
@@ -16,9 +16,8 @@ class Loader {
   appNameRegex = () => {
     const name = this.appName();
     if (!name) {
-      console.log("ENV var `NAME` is missing. Please make sure you define it")
-
-      return null
+      console.log("ENV var `NAME` is missing. Please make sure you define it");
+      return null;
     }
     return new RegExp(`^${this.appName().toUpperCase()}__`, 'g');
   }

--- a/src/loader/index.test.js
+++ b/src/loader/index.test.js
@@ -71,7 +71,10 @@ describe("toCombinedObject", () => {
 
     return loader.toCombinedObject(getVars).then((combinedConfig) => {
       const keys = Object.keys(combinedConfig);
-      expect(keys.length).toBe(9); // one secret and the prev config
+      console.log(keys);
+      // We have 9 config items and secrets total. Because we add the name
+      // to the config vars, we should have +1 on keys
+      expect(keys.length).toBe(10); // one secret and the prev config
     });
   });
 


### PR DESCRIPTION
1. Fixing the bug where the module would explode if you did not define
the NAME env var
2. Adding a final merge to have `name` on the config coming from the
appp name if you did not namespace it under the app name in the env var
standard of `APP_NAME__NAME`