### PR TITLE
Glob 18937 extend config merging

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
-  "plugins": ["transform-class-constructor-call"],
   "presets": ["es2015", "stage-2"]
+  "plugins": ["transform-decorators-legacy", "transform-class-constructor-call"],
 }

--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,6 @@
+
+popo
 {
-  "presets": ["es2015", "stage-2"]
-  "plugins": ["transform-decorators-legacy", "transform-class-constructor-call"],
+  "presets": ["es2015", "stage-2"],
+  "plugins": ["transform-decorators-legacy", "transform-class-constructor-call"]
 }

--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,7 @@
-
-popo
 {
   "presets": ["es2015", "stage-2"],
-  "plugins": ["transform-decorators-legacy", "transform-class-constructor-call"]
+  "plugins": [
+    "transform-decorators-legacy",
+    "transform-class-constructor-call"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -13,10 +13,13 @@
   "author": "Avi Zurel",
   "license": "MIT",
   "dependencies": {
+    "bottlejs": "^1.6.2",
     "credstash": "https://github.com/KensoDev/node-credstash.git#hotfix/credstash",
+    "fsevents": "1.1.2",
     "lodash": "^4.17.4"
   },
   "devDependencies": {
+    "babel": "^6.23.0",
     "babel-cli": "^6.24.1",
     "babel-core": "^6.24.1",
     "babel-eslint": "^7.2.3",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
     "babel-plugin-transform-async-to-generator": "^6.24.1",
     "babel-plugin-transform-class-constructor-call": "^6.24.1",
+    "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-plugin-transform-es2015-destructuring": "^6.23.0",
     "babel-plugin-transform-es2015-parameters": "^6.24.1",
     "babel-plugin-transform-flow-strip-types": "^6.22.0",

--- a/src/.babelrc
+++ b/src/.babelrc
@@ -1,4 +1,0 @@
-{
-  "plugins": ["transform-class-constructor-call"],
-  "presets": ["es2015", "stage-2"]
-}

--- a/src/configMaker.js
+++ b/src/configMaker.js
@@ -32,7 +32,7 @@ const mergeConfigSections = (metadata, sections) => {
         },
         metadata,
     );
-}
+};
 
 
 /* Build the full application configuration.

--- a/src/configMaker.js
+++ b/src/configMaker.js
@@ -1,4 +1,4 @@
-import _ from "lodash";
+import { get, merge, set } from "lodash";
 import { camelCase } from "./helpers";
 
 const SEPARATOR = "__";
@@ -12,15 +12,56 @@ const makeConfig = (vars) => {
     }).join(".");
 
     const configObject = {};
-    _.set(configObject, assignPath, vars[configKey]);
+    set(configObject, assignPath, vars[configKey]);
 
     configObjectsArray.push(configObject);
     return true;
   });
 
-  return _.merge({}, ...configObjectsArray);
+  return merge({}, ...configObjectsArray);
+};
+
+/* Build configuration by merging defaults sections.
+ */
+const mergeConfigSections = (metadata, sections) => {
+    return Object.keys(sections).reduce(
+        (acc, key) => {
+            const section = {};
+            section[key] = sections[key](metadata);
+            return merge(acc, section);
+        },
+        metadata,
+    );
+}
+
+
+/* Build the full application configuration.
+ */
+const buildConfig = (defaults, vars) => {
+    const injector = getInjector();
+
+    // load environment variables
+    const environ = makeConfig(vars);
+
+    // generate metadata
+    const metadata = {
+        environment: get(environ, 'environment', 'dev'),
+        ip: get(environ, 'ip', '0.0.0.0'),
+        port: Number(get(environ, 'port', 3006)),
+    };
+
+    const config = merge(
+        // generate configuration defaults (using metadata)
+        mergeConfigSections(metadata, defaults),
+        // override with environment settings
+        environ,
+    );
+
+    // save config and return
+    injector.factory('config', () => config);
+    return config;
 };
 
 module.exports = {
-  makeConfig,
+    buildConfig,
 };

--- a/src/configMaker.js
+++ b/src/configMaker.js
@@ -64,4 +64,5 @@ const buildConfig = (defaults, vars) => {
 
 module.exports = {
     buildConfig,
+    makeConfig,
 };

--- a/src/configMaker.test.js
+++ b/src/configMaker.test.js
@@ -1,4 +1,4 @@
-import { makeConfig } from "./configMaker";
+import { makeConfig, mergeConfigSections } from "./configMaker";
 
 const vars = {
   GROUP__VAR: 'X',
@@ -16,4 +16,52 @@ test("should merge all the configuration", () => {
   const config = makeConfig(vars);
   expect(config.group.var).toEqual("X");
   expect(config.secretVar).toEqual("SECRET_VALUE");
+});
+
+
+/* Test config merging.  */
+function foo() {
+    return {
+        bar: 'baz',
+    };
+}
+
+
+function bar() {
+    return {
+        baz: 'qux',
+    };
+}
+
+
+test('merging configuration sections', () => {
+    it('invokes callables', () => {
+        const sections = {
+            foo,
+            bar,
+        };
+        expect(
+            mergeConfigSections({}, sections),
+        ).toEqual({
+            foo: {
+                bar: 'baz',
+            },
+            bar: {
+                baz: 'qux',
+            },
+        });
+    });
+
+    it('overrides with later values', () => {
+        const sections = {
+            foo,
+        };
+        expect(
+            mergeConfigSections({ foo: { bar: 'qux' } }, sections),
+        ).toEqual({
+            foo: {
+                bar: 'baz',
+            },
+        });
+    });
 });

--- a/src/di/__tests__/binding.test.js
+++ b/src/di/__tests__/binding.test.js
@@ -1,0 +1,68 @@
+import binding from '../binding';
+import getInjector from '../getInjector';
+
+const TEST_CLASS_A_VALUE = 'test-class-a-value';
+const TEST_CLASS_B_VALUE = 'test-class-b-value';
+
+@binding()
+// eslint-disable-next-line
+class TestClassA {
+    constructor() {
+        this.value = TEST_CLASS_A_VALUE;
+    }
+
+    getSomeValue() {
+        return this.value;
+    }
+}
+
+@binding()
+// eslint-disable-next-line
+class TestClassB {
+    constructor() {
+        this.value = TEST_CLASS_B_VALUE;
+    }
+}
+
+// eslint-disable-next-line
+class TestClassC {}
+
+@binding('customNameForD')
+// eslint-disable-next-line
+class TestClassD {
+    constructor(graph) {
+        this.testClassA = graph.testClassA;
+    }
+
+    get aValue() {
+        return this.testClassA.getSomeValue();
+    }
+}
+
+describe('Injector binding', () => {
+    const injector = getInjector();
+
+    it('Should not find non-registered dependency', () => {
+        expect(injector.container.testClassC).toBeUndefined();
+    });
+
+    it('Should retrieve registered class instance', () => {
+        const testClassAInstance = injector.container.testClassA;
+
+        expect(testClassAInstance.value).toEqual(TEST_CLASS_A_VALUE);
+    });
+
+    it('Should retrieve dependency by name', () => {
+        const classDInstance = injector.container.customNameForD;
+
+        expect(classDInstance.aValue).toEqual(TEST_CLASS_A_VALUE);
+    });
+
+    it('Should not allow circular dependencies', () => {
+        injector.factory('first', graph => graph.second);
+        injector.factory('second', graph => graph.first);
+
+        expect(() => injector.container.first).toThrow();
+        expect(() => injector.container.second).toThrow();
+    });
+});

--- a/src/di/__tests__/getInjector.test.js
+++ b/src/di/__tests__/getInjector.test.js
@@ -1,0 +1,14 @@
+import { Bottle } from 'bottlejs';
+import getInjector, { globalObject, INJECTOR_KEY } from '../getInjector';
+
+describe('getInjector', () => {
+    it('should create Injector instance if it does not exist', () => {
+        expect(globalObject[INJECTOR_KEY]).toBeUndefined();
+
+        const injector = getInjector();
+
+        expect(injector).toBeInstanceOf(Bottle);
+        expect(globalObject[INJECTOR_KEY]).toBeInstanceOf(Bottle);
+        expect(globalObject[INJECTOR_KEY]).toEqual(injector);
+    });
+});

--- a/src/di/binding.js
+++ b/src/di/binding.js
@@ -1,0 +1,29 @@
+import { camelCase } from 'lodash';
+import getInjector from './getInjector';
+
+function nodeName(tokenOrClass) {
+    if (typeof tokenOrClass === 'string') {
+        return tokenOrClass;
+    }
+
+    return camelCase(tokenOrClass.name);
+}
+
+/*
+ * Class decorator, registering the given class in the injector.
+ * It assumes, that the target class has a constructor
+ * expecting single argument - an injector graph.
+ *
+ * nullableNodeName - the name of the dependency can be provided,
+ * if not `class.name` will be picked as a name, e.g. class `TestClass`
+ * will be accessible on the graph under `graph.testClass` key.
+ */
+export default function binding(nullableNodeName) {
+    const bottle = getInjector();
+
+    return (TargetClass) => {
+        const name = nullableNodeName || nodeName(TargetClass);
+
+        bottle.factory(name, graph => new TargetClass(graph));
+    };
+}

--- a/src/di/getInjector.js
+++ b/src/di/getInjector.js
@@ -1,0 +1,17 @@
+import { Bottle } from 'bottlejs';
+
+export const INJECTOR_KEY = Symbol.for('service-name');
+export const globalObject = global;
+
+/*
+ * Injector factory method and injector singleton guard.
+ * Wires the Injector instance to the `global` object,
+ * to assure there exists exacly one instance of injector.
+ */
+export default function getInjector() {
+    if (!globalObject[INJECTOR_KEY]) {
+        globalObject[INJECTOR_KEY] = new Bottle();
+    }
+
+    return globalObject[INJECTOR_KEY];
+}

--- a/src/di/index.js
+++ b/src/di/index.js
@@ -1,0 +1,2 @@
+export { default as binding } from './binding';
+export { default as getInjector } from './getInjector';

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,9 @@
 import { Loader } from "./loader";
-import { makeConfig } from "./configMaker";
+import { buildConfig } from "./configMaker";
 import secretLoader from "./secretLoader";
 
 module.exports = {
   Loader,
-  makeConfig,
+  buildConfig,
   secretLoader,
 };

--- a/src/loader/index.js
+++ b/src/loader/index.js
@@ -15,7 +15,7 @@ class Loader {
 
   appNameRegex = () => {
     return new RegExp(`^${this.appName().toUpperCase()}__`, 'g');
-  }
+  };
 
   toStandardObject = () => {
     const allKeys = this.all();
@@ -28,7 +28,7 @@ class Loader {
 
       return res;
     }, {});
-  }
+  };
 
   toCombinedObject = (getVars = Credstash) => {
     return new Promise((resolve, reject) => {
@@ -52,7 +52,7 @@ class Loader {
         resolve(envObject);
       }
     });
-  }
+  };
 
   all = () => {
     const keys = Object.keys(process.env);

--- a/yarn.lock
+++ b/yarn.lock
@@ -434,9 +434,9 @@ babel-plugin-syntax-class-properties@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz#d7eb23b79a317f8543962c505b827c7d6cac27de"
 
-babel-plugin-syntax-decorators@^6.13.0:
+babel-plugin-syntax-decorators@^6.1.18, babel-plugin-syntax-decorators@^6.13.0:
   version "6.13.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz#312563b4dbde3cc806cee3e416cceeaddd11ac0b"
+  resolved "https://globality.jfrog.io/globality/api/npm/npm/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz#312563b4dbde3cc806cee3e416cceeaddd11ac0b"
 
 babel-plugin-syntax-dynamic-import@^6.18.0:
   version "6.18.0"
@@ -490,6 +490,14 @@ babel-plugin-transform-class-properties@^6.24.1:
     babel-plugin-syntax-class-properties "^6.8.0"
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
+
+babel-plugin-transform-decorators-legacy@^1.3.4:
+  version "1.3.4"
+  resolved "https://globality.jfrog.io/globality/api/npm/npm/babel-plugin-transform-decorators-legacy/-/babel-plugin-transform-decorators-legacy-1.3.4.tgz#741b58f6c5bce9e6027e0882d9c994f04f366925"
+  dependencies:
+    babel-plugin-syntax-decorators "^6.1.18"
+    babel-runtime "^6.2.0"
+    babel-template "^6.3.0"
 
 babel-plugin-transform-decorators@^6.24.1:
   version "6.24.1"
@@ -819,14 +827,14 @@ babel-register@^6.24.1:
     mkdirp "^0.5.1"
     source-map-support "^0.4.2"
 
-babel-runtime@^6.18.0, babel-runtime@^6.22.0:
+babel-runtime@^6.18.0, babel-runtime@^6.2.0, babel-runtime@^6.22.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.23.0.tgz#0a9489f144de70efb3ce4300accdb329e2fc543b"
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
-babel-template@^6.16.0, babel-template@^6.24.1:
+babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.3.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.24.1.tgz#04ae514f1f93b3a2537f2a0f60a5a45fb8308333"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -867,6 +867,10 @@ babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.23.0, babel-types@^6.24
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
 
+babel@^6.23.0:
+  version "6.23.0"
+  resolved "https://globality.jfrog.io/globality/api/npm/npm/babel/-/babel-6.23.0.tgz#d0d1e7d803e974765beea3232d4e153c0efb90f4"
+
 babylon@^6.11.0, babylon@^6.13.0, babylon@^6.15.0, babylon@^6.17.0:
   version "6.17.1"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.17.1.tgz#17f14fddf361b695981fe679385e4f1c01ebd86f"
@@ -900,6 +904,10 @@ boom@2.x.x:
   resolved "https://registry.yarnpkg.com/boom/-/boom-2.10.1.tgz#39c8918ceff5799f83f9492a848f625add0c766f"
   dependencies:
     hoek "2.x.x"
+
+bottlejs@^1.6.2:
+  version "1.7.0"
+  resolved "https://globality.jfrog.io/globality/api/npm/npm/bottlejs/-/bottlejs-1.7.0.tgz#6365d72c4f9c61f204797e944f1e7d4b23d90d3c"
 
 brace-expansion@^1.1.7:
   version "1.1.7"
@@ -1215,6 +1223,10 @@ detect-indent@^4.0.0:
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-4.0.0.tgz#f76d064352cdf43a1cb6ce619c4ee3a9475de208"
   dependencies:
     repeating "^2.0.0"
+
+detect-libc@^1.0.2:
+  version "1.0.3"
+  resolved "https://globality.jfrog.io/globality/api/npm/npm/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
 
 diff@^3.2.0:
   version "3.2.0"
@@ -1596,6 +1608,13 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
 
+fsevents@1.1.2:
+  version "1.1.2"
+  resolved "https://globality.jfrog.io/globality/api/npm/npm/fsevents/-/fsevents-1.1.2.tgz#3282b713fb3ad80ede0e9fcf4611b5aa6fc033f4"
+  dependencies:
+    nan "^2.3.0"
+    node-pre-gyp "^0.6.36"
+
 fsevents@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.1.1.tgz#f19fd28f43eeaf761680e519a203c4d0b3d31aff"
@@ -1749,7 +1768,7 @@ has@^1.0.1:
   dependencies:
     function-bind "^1.0.2"
 
-hawk@~3.1.3:
+hawk@3.1.3, hawk@~3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/hawk/-/hawk-3.1.3.tgz#078444bd7c1640b0fe540d2c9b73d59678e8e1c4"
   dependencies:
@@ -2537,6 +2556,22 @@ node-pre-gyp@^0.6.29:
     tar "^2.2.1"
     tar-pack "^3.4.0"
 
+node-pre-gyp@^0.6.36:
+  version "0.6.39"
+  resolved "https://globality.jfrog.io/globality/api/npm/npm/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz#c00e96860b23c0e1420ac7befc5044e1d78d8649"
+  dependencies:
+    detect-libc "^1.0.2"
+    hawk "3.1.3"
+    mkdirp "^0.5.1"
+    nopt "^4.0.1"
+    npmlog "^4.0.2"
+    rc "^1.1.7"
+    request "2.81.0"
+    rimraf "^2.6.1"
+    semver "^5.3.0"
+    tar "^2.2.1"
+    tar-pack "^3.4.0"
+
 nopt@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.1.tgz#d0d4685afd5415193c8c7505602d0d17cd64474d"
@@ -2932,7 +2967,7 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
-request@^2.79.0, request@^2.81.0:
+request@2.81.0, request@^2.79.0, request@^2.81.0:
   version "2.81.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
   dependencies:


### PR DESCRIPTION
WIP not ready to merge, but opening a review to get a hand and collaborate.

What am I trying to do?  I am trying to move some config utils from `leif`/`styx` to `nodule-config`. One thing I want to play around with is moving some of the `di` code in both projects to here and seeing if we can make this more like `microcosm`.

The problem I have no is that I can't get `yarn install` to work. It fails with:

```
success Already up-to-date.
$ npm run build

> nodule-config@1.0.8-pre build /Users/dino/globality/nodule-config
> babel src --out-dir dist

src/booleanParser.js -> dist/booleanParser.js
src/booleanParser.test.js -> dist/booleanParser.test.js
src/configMaker.js -> dist/configMaker.js
src/configMaker.test.js -> dist/configMaker.test.js
SyntaxError: src/di/__tests__/binding.test.js: Decorators are not officially supported yet in 6.x pending a proposal update.
However, if you need to use them you can install the legacy decorators transform with:

npm install babel-plugin-transform-decorators-legacy --save-dev

and add the following line to your .babelrc file:

{
  "plugins": ["transform-decorators-legacy"]
}

The repo url is: https://github.com/loganfsmyth/babel-plugin-transform-decorators-legacy.
    
   7 | @binding()
   8 | // eslint-disable-next-line
>  9 | class TestClassA {
     | ^
  10 |     constructor() {
  11 |         this.value = TEST_CLASS_A_VALUE;
  12 |     }
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! nodule-config@1.0.8-pre build: `babel src --out-dir dist`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the nodule-config@1.0.8-pre build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/dino/.npm/_logs/2018-03-12T21_59_08_391Z-debug.log
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```
In particular it fails on `babel src --out-dir dist`. It looks like the babelrc is being ignored because ` babel src --out-dir dist --plugins transform-decorators-legacy` works for me. 

Once I get this working, I want to link `styx`/`leif` locally to test this out and see it work and remove some copied code between `styx` and `leif`. After that some follow ups we might want:

- make defaults work more nicely, right now styx/leif just declare all of their defaults in a `config` module rather than defining the defaults inline and using some sort of registration system
- style refresh `nodule-config`. The structure in `nodule-config` seems to be a bit old. I want to move everything to using `__tests__` style tests rather than separate test files.
- I'm hoping that once I see styx/leif working other important things will be clearer.