### PR TITLE
Make default scope explicit

### DIFF
--- a/src/bind.js
+++ b/src/bind.js
@@ -1,7 +1,8 @@
+import { DEFAULT_SCOPE } from './constants';
 import { getDefaults, getInjector } from './injector';
 
 
-export function bind(name, factory, scope = null) {
+export function bind(name, factory, scope = DEFAULT_SCOPE) {
     const bottle = getInjector(scope);
 
     if (!bottle.providerMap[name]) {
@@ -15,7 +16,7 @@ function initDefaults() {
 }
 
 
-export function setDefaults(name, object, scope = null) {
+export function setDefaults(name, object, scope = DEFAULT_SCOPE) {
     bind('defaults', initDefaults);
 
     const defaults = getDefaults(scope);

--- a/src/constants.js
+++ b/src/constants.js
@@ -2,4 +2,6 @@
 
 export const CREDSTASH_PREFIX = 'MICROCOSM';
 
+export const DEFAULT_SCOPE = 'nodule';
+
 export const SEPARATOR = '__';

--- a/src/injector.js
+++ b/src/injector.js
@@ -1,8 +1,10 @@
 import { Bottle } from 'bottlejs';
 
+import { DEFAULT_SCOPE } from './constants';
 
-export function getInjector(scope = null) {
-    const key = scope || 'nodule';
+
+export function getInjector(scope = DEFAULT_SCOPE) {
+    const key = scope || DEFAULT_SCOPE;
 
     const bottle = Bottle.pop(key);
 
@@ -13,22 +15,22 @@ export function getInjector(scope = null) {
     return bottle;
 }
 
-export function getContainer(scope = null) {
+export function getContainer(scope = DEFAULT_SCOPE) {
     const { container } = getInjector(scope);
     return container;
 }
 
-export function getConfig(scope = null) {
+export function getConfig(scope = DEFAULT_SCOPE) {
     const { config } = getContainer(scope);
     return config;
 }
 
-export function getDefaults(scope = null) {
+export function getDefaults(scope = DEFAULT_SCOPE) {
     const { defaults } = getContainer(scope);
     return defaults;
 }
 
-export function getMetadata(scope = null) {
+export function getMetadata(scope = DEFAULT_SCOPE) {
     const { metadata } = getContainer(scope);
     return metadata;
 }

--- a/src/loaders/convert.js
+++ b/src/loaders/convert.js
@@ -1,6 +1,6 @@
 import { camelCase, set } from 'lodash';
 
-import { SEPARATOR } from './constants';
+import { SEPARATOR } from '../constants';
 
 
 /* Transform environment variables to dotted keys.

--- a/src/loaders/credstash.js
+++ b/src/loaders/credstash.js
@@ -2,7 +2,7 @@ import { merge } from 'lodash';
 
 import Credstash from 'credstash';
 
-import { CREDSTASH_PREFIX } from './constants';
+import { CREDSTASH_PREFIX } from '../constants';
 import toObject from './convert';
 
 

--- a/src/loaders/environ.js
+++ b/src/loaders/environ.js
@@ -1,6 +1,6 @@
 import { merge } from 'lodash';
 
-import { SEPARATOR } from './constants';
+import { SEPARATOR } from '../constants';
 import toObject from './convert';
 
 

--- a/src/nodule.js
+++ b/src/nodule.js
@@ -1,4 +1,5 @@
 import { bind } from './bind';
+import { DEFAULT_SCOPE } from './constants';
 import { getContainer } from './injector';
 import {
     loadEach,
@@ -11,7 +12,7 @@ import Metadata from './metadata';
 
 export default class Nodule {
 
-    constructor(metadata, loaders = null, scope = null) {
+    constructor(metadata, loaders = null, scope = DEFAULT_SCOPE) {
         this.metadata = new Metadata(metadata);
         this.loaders = loaders || [];
         this.scope = scope;


### PR DESCRIPTION
It's confusing to use both `null` and the string `nodule` as defaults.