### PR TITLE
[FEATURE] adding fromObjects loader for multiple objects

### DIFF
--- a/src/__tests__/nodule.test.js
+++ b/src/__tests__/nodule.test.js
@@ -64,4 +64,18 @@ describe('Nodule', () => {
             foo: 'object',
         });
     });
+
+    it('loads from objects', async () => {
+        const obj1 = { foo: { bar: 'baz' } };
+        const obj2 = { foo: { baz: 'bar' } };
+        const config = await nodule.fromEnvironment()
+            .fromObjects(obj1, obj2).load();
+
+        expect(config).toEqual({
+            foo: {
+                bar: 'baz',
+                baz: 'bar',
+            },
+        });
+    });
 });

--- a/src/nodule.js
+++ b/src/nodule.js
@@ -1,3 +1,4 @@
+import merge from 'lodash/merge';
 import { bind } from './bind';
 import { DEFAULT_SCOPE } from './constants';
 import { getContainer } from './injector';
@@ -34,6 +35,11 @@ export default class Nodule {
     }
 
     fromObject(obj) {
+        return this.from(loadFromObject(obj));
+    }
+
+    fromObjects(...objects) {
+        const obj = merge({}, ...objects);
         return this.from(loadFromObject(obj));
     }
 


### PR DESCRIPTION
Why?
In tests, we sometimes need to put multiple mocked client responses,
currently, this means using multiple `fromObject` calls, which is pretty
clumsy. Thus, a `fromObjects` function is born