### PR TITLE
Disable loading from credstash in debug.

### DIFF
--- a/src/loaders/credstash.js
+++ b/src/loaders/credstash.js
@@ -46,7 +46,7 @@ async function loadSecrets(table, semver) {
 
 
 export default async function loadFromCredstash(metadata) {
-    if (metadata.testing) {
+    if (metadata.testing || metadata.debug) {
         // do not load from external sources during unit tests
         return {
         };


### PR DESCRIPTION
Why? Otherwise there's no way to turn loading from credsatsh off nicely
for local development.

Testing locally and it does what we want.