### PR TITLE
Add support for dotenv.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "dependencies": {
         "aws-sdk": "^2.231.1",
         "bottlejs": "^1.7.0",
+        "dotenv": "^6.0.0",
         "lodash": "^4.17.5"
     },
     "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+export { env } from './loaders/env';
+
 export { bind, setDefaults } from './bind';
 export {
     clearBinding,

--- a/src/loaders/env.js
+++ b/src/loaders/env.js
@@ -1,0 +1,3 @@
+import dotenv from 'dotenv';
+
+export default dotenv.config({ silent: true });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1356,6 +1356,10 @@ domexception@^1.0.0:
   dependencies:
     webidl-conversions "^4.0.2"
 
+dotenv@^6.0.0:
+  version "6.0.0"
+  resolved "https://globality.jfrog.io/globality/api/npm/npm/dotenv/-/dotenv-6.0.0.tgz#24e37c041741c5f4b25324958ebbc34bca965935"
+
 ecc-jsbn@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
@@ -3731,18 +3735,6 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
 sinon@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/sinon/-/sinon-4.5.0.tgz#427ae312a337d3c516804ce2754e8c0d5028cb04"
-  dependencies:
-    "@sinonjs/formatio" "^2.0.0"
-    diff "^3.1.0"
-    lodash.get "^4.4.2"
-    lolex "^2.2.0"
-    nise "^1.2.0"
-    supports-color "^5.1.0"
-    type-detect "^4.0.5"
-
-sinon@^5.0.3:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/sinon/-/sinon-5.0.3.tgz#9950f1616187ff0cd7d75a60d66bc27fed569945"
   dependencies:
     "@sinonjs/formatio" "^2.0.0"
     diff "^3.1.0"


### PR DESCRIPTION
## What is this?

This will allow us to auto-load environment variables configured in .env files,
instead of having to load them manually.

### Does this change affect other projects?

This will not require any code changes on gateways, however it **will** require the .env files to have a slightly different format, namely: instead of `export VAR_NAME=value`, dotenv expects `VAR_NAME=value`, so this has implications on all gateway code that uses .env files.
That said, this will not break if the .env file remains unchanged and we can still use the manual `source .env` option until all gateways are updated.

### Naming conventions

I am not sure the variables / file names I used comply with the conventions we normally use for nodule* projects, so I'd welcome any alternatives you might suggest.