### PR TITLE
Add declassified configuration

### DIFF
--- a/src/__tests__/classifiedConfig.test.js
+++ b/src/__tests__/classifiedConfig.test.js
@@ -1,0 +1,38 @@
+import { getInjector } from '../injector';
+import { loadFromObject } from '../loaders';
+import Nodule from '../nodule';
+
+
+describe('Nodule Classified Config', () => {
+    let nodule;
+
+    beforeEach(async () => {
+        nodule = Nodule.testing();
+        await nodule.fromEnvironment(
+        ).from(
+            loadFromObject({
+                foo: 'object',
+            }),
+            true,
+        ).from(
+            loadFromObject({
+                bar: 'object',
+            }),
+        ).load();
+    });
+
+    it('classifies configuration', () => {
+        const bottle = getInjector();
+        const { container } = bottle;
+
+        expect(container.config).toEqual({
+            foo: 'object',
+            bar: 'object',
+        });
+
+        expect(container.declassifiedConfig).toEqual({
+            bar: 'object',
+        });
+
+    });
+});

--- a/src/nodule.js
+++ b/src/nodule.js
@@ -41,6 +41,7 @@ export default class Nodule {
     load() {
         const { defaults, metadata } = getContainer(null, this.scope);
 
+        // NB: This can be further optimized to load each loader only once
         const loader = loadEach(
             loadFromObject(defaults),
             ...this.loaders,

--- a/src/nodule.js
+++ b/src/nodule.js
@@ -1,12 +1,7 @@
 import { bind } from './bind';
 import { DEFAULT_SCOPE } from './constants';
 import { getContainer } from './injector';
-import {
-    loadEach,
-    loadFromSecretsManager,
-    loadFromEnvironment,
-    loadFromObject,
-} from './loaders';
+import { loadEach, loadFromEnvironment, loadFromObject, loadFromSecretsManager } from './loaders';
 import Metadata from './metadata';
 
 
@@ -17,16 +12,22 @@ export default class Nodule {
         this.loaders = loaders || [];
         this.scope = scope;
 
+        // Declassified loaders contain configuration that does not contain any secrets
+        this.declassifiedLoaders = [];
+
         bind('metadata', () => this.metadata);
     }
 
-    from(value) {
+    from(value, classified = false) {
         this.loaders.push(value);
+        if (!classified) {
+            this.declassifiedLoaders.push(value);
+        }
         return this;
     }
 
     fromSecretsManager() {
-        return this.from(loadFromSecretsManager);
+        return this.from(loadFromSecretsManager, true);
     }
 
     fromEnvironment() {
@@ -44,9 +45,18 @@ export default class Nodule {
             loadFromObject(defaults),
             ...this.loaders,
         );
-        return loader(metadata).then((config) => {
-            bind('config', () => config);
-            return config;
+
+        const declassifiedLoader = loadEach(
+            loadFromObject(defaults),
+            ...this.declassifiedLoaders,
+        );
+
+        return declassifiedLoader(metadata).then((declassifiedConfig) => {
+            bind('declassifiedConfig', () => declassifiedConfig);
+            return loader(metadata).then((config) => {
+                bind('config', () => config);
+                return config;
+            });
         });
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3740,18 +3740,6 @@ sinon@^4.5.0:
     supports-color "^5.1.0"
     type-detect "^4.0.5"
 
-sinon@^5.0.3:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/sinon/-/sinon-5.0.3.tgz#9950f1616187ff0cd7d75a60d66bc27fed569945"
-  dependencies:
-    "@sinonjs/formatio" "^2.0.0"
-    diff "^3.1.0"
-    lodash.get "^4.4.2"
-    lolex "^2.2.0"
-    nise "^1.2.0"
-    supports-color "^5.1.0"
-    type-detect "^4.0.5"
-
 slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"


### PR DESCRIPTION
Why?

We want to support exposing configuration however some configuration contains secrets and we don't want to expose it. To avoid doing that we create declassifiedConfig.