### PR TITLE
GLOB-39250 - Make babel-polyfill dependency, not devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "license": "MIT",
     "dependencies": {
         "aws-sdk": "^2.231.1",
+        "babel-polyfill": "^6.26.0",
         "bottlejs": "^1.7.0",
         "lodash": "^4.17.5"
     },
@@ -25,7 +26,6 @@
         "babel-plugin-transform-decorators-legacy": "^1.3.4",
         "babel-plugin-transform-object-rest-spread": "^6.26.0",
         "babel-plugin-transform-runtime": "^6.23.0",
-        "babel-polyfill": "^6.26.0",
         "babel-preset-env": "^1.6.1",
         "eslint": "^4.18.2",
         "eslint-config-airbnb-base": "^12.1.0",


### PR DESCRIPTION
**Description**: While working on updating `xavier` to use `babel` v7 I've noticed that `nodule-config` has `babel-polyfill` listed as a `devDependency`. This is incorrect, because this polyfill ins injected during runtime and it should be `dependency`. See: https://babeljs.io/docs/en/babel-polyfill#installation