### PR TITLE
Added context to use updated secrets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,6 @@ jobs:
       - restore_cache:
           keys:
           - v1-dependencies-{{ checksum "yarn.lock" }}
-          - v1-dependencies-
 
       - run:
           name: Install Dependencies
@@ -94,14 +93,22 @@ workflows:
 
   build:
     jobs:
-      - checkout
+      - checkout:
+          context: 
+          - Globality-Common
       - lint:
+          context: 
+          - Globality-Common
           requires:
             - checkout
       - test:
+          context: 
+          - Globality-Common
           requires:
             - checkout
       - build:
+          context: 
+          - Globality-Common
           requires:
             - lint
             - test
@@ -109,12 +116,16 @@ workflows:
   release:
     jobs:
       - checkout:
+          context: 
+          - Globality-Common
           filters:
             tags:
               only: /[0-9]+(\.[0-9]+)*/
             branches:
               ignore: /.*/
       - lint:
+          context: 
+          - Globality-Common
           filters:
             tags:
               only: /[0-9]+(\.[0-9]+)*/
@@ -123,6 +134,8 @@ workflows:
           requires:
             - checkout
       - test:
+          context: 
+          - Globality-Common
           filters:
             tags:
               only: /[0-9]+(\.[0-9]+)*/
@@ -131,6 +144,8 @@ workflows:
           requires:
             - checkout
       - build:
+          context: 
+          - Globality-Common
           filters:
             tags:
               only: /[0-9]+(\.[0-9]+)*/
@@ -139,6 +154,8 @@ workflows:
           requires:
             - test
       - deploy:
+          context: 
+          - Globality-Common
           filters:
             tags:
               only: /[0-9]+(\.[0-9]+)*/

--- a/.globality/build.json
+++ b/.globality/build.json
@@ -1,7 +1,8 @@
 {
-  "type": "node-module",
   "params": {
     "name": "nodule-config",
     "open_source": true
-  }
+  },
+  "type": "node-module",
+  "version": "2021.3.1"
 }


### PR DESCRIPTION
This should fix the issue of npm publish which is more likely caused by deprecated npm credential.