### PR TITLE
upgrade to lodash@^4.17.21

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ typings/
 # dotenv environment variables file
 .env
 lib
+
+# IDEs
+.idea

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@globality/nodule-config",
-    "version": "2.13.5",
+    "version": "2.13.6",
     "description": "Opinionated configuration for Node application",
     "main": "lib/",
     "repository": "https://github.com/globality-corp/nodule-config",
@@ -15,7 +15,7 @@
     "dependencies": {
         "aws-sdk": "2.829.0",
         "bottlejs": "1.7.2",
-        "lodash": "4.17.20"
+        "lodash": "^4.17.21"
     },
     "devDependencies": {
         "aws-sdk-mock": "^5.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3251,15 +3251,15 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
-lodash@4.17.20:
-  version "4.17.20"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
-  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
-
 lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
+lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 loose-envify@^1.0.0:
   version "1.4.0"


### PR DESCRIPTION
* Unpin `lodash` version;
* Upgrade to `4.17.21` which fixes vulnerability CVE-2021-23337;
* Note this doesn't cover development dependencies;