### PR TITLE
fix: use relative path for src/metadata imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@globality/nodule-config",
-    "version": "2.15.3",
+    "version": "2.15.4",
     "description": "Opinionated configuration for Node application",
     "main": "lib/",
     "repository": "https://github.com/globality-corp/nodule-config",

--- a/src/loaders/environ.ts
+++ b/src/loaders/environ.ts
@@ -1,5 +1,5 @@
 import { merge } from "lodash";
-import Metadata from "src/metadata";
+import Metadata from "../metadata";
 
 import { SEPARATOR } from "../constants";
 

--- a/src/loaders/environ.ts
+++ b/src/loaders/environ.ts
@@ -1,7 +1,7 @@
 import { merge } from "lodash";
-import Metadata from "../metadata";
 
 import { SEPARATOR } from "../constants";
+import Metadata from "../metadata";
 
 import toObject from "./convert";
 

--- a/src/loaders/secretsManager.ts
+++ b/src/loaders/secretsManager.ts
@@ -1,6 +1,6 @@
 import AWS from "aws-sdk";
 import { camelCase } from "lodash";
-import Metadata from "src/metadata";
+import Metadata from "../metadata";
 
 import { CREDSTASH_PREFIX } from "../constants";
 

--- a/src/loaders/secretsManager.ts
+++ b/src/loaders/secretsManager.ts
@@ -1,8 +1,8 @@
 import AWS from "aws-sdk";
 import { camelCase } from "lodash";
-import Metadata from "../metadata";
 
 import { CREDSTASH_PREFIX } from "../constants";
+import Metadata from "../metadata";
 
 import { convert } from "./convert";
 


### PR DESCRIPTION
## Why

The absolute imports from "src/metadata" are causing [consumer builds to fail due ](https://drone-internal.dev.globality.io/globality-corp/nodule-openapi/7/1/6)to:

```
node_modules/@globality/nodule-config/lib/loaders/environ.d.ts(1,22): error TS2307: Cannot find module 'src/metadata' or its corresponding type declarations.
node_modules/@globality/nodule-config/lib/loaders/secretsManager.d.ts(2,22): error TS2307: Cannot find module 'src/metadata' or its corresponding type declarations.
```

These imports need to be relative i.e. from `../metadata` for the TypeScript compilation to succeed.

## What

- Updated the two imports to be relative.
- Bumped the package version.